### PR TITLE
Make new files public in S3

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -62,6 +62,7 @@ return [
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
+            'visibility' => 'public',
         ],
 
     ],


### PR DESCRIPTION
Changes the visibility in S3 so files are accessible and won't require an ACL to view. 