### PR TITLE
Update lenses and metrics to hide others' information

### DIFF
--- a/app/Nova/Lenses/SellerView.php
+++ b/app/Nova/Lenses/SellerView.php
@@ -23,7 +23,7 @@ class SellerView extends Lens
     public static function query(LensRequest $request, $query)
     {
         return $request->withOrdering($request->withFilters(
-            $query->withTrashed()->whereJsonContains('tags', 'Sold')->orWhereJsonContains('tags', 'Selling')
+            $query->mine()->withTrashed()->whereJsonContains('tags', 'Sold')->orWhereJsonContains('tags', 'Selling')
         ));
     }
 

--- a/app/Nova/Metrics/CollectionAcquisitionBreakdown.php
+++ b/app/Nova/Metrics/CollectionAcquisitionBreakdown.php
@@ -18,9 +18,9 @@ class CollectionAcquisitionBreakdown extends Partition
      */
     public function calculate(NovaRequest $request)
     {
-      return $this->count($request, Item::class, 'acquisition_id')
+      return $this->count($request, Item::mine(), 'acquisition_id')
         ->label(function($value) {
-          return optional(Acquisition::where('id', $value)->first())->title;
+          return optional(Acquisition::where('id', $value)->first())->title ?? 'n/a';
         });
     }
 

--- a/app/Nova/Metrics/CollectionConditionBreakdown.php
+++ b/app/Nova/Metrics/CollectionConditionBreakdown.php
@@ -18,9 +18,9 @@ class CollectionConditionBreakdown extends Partition
      */
     public function calculate(NovaRequest $request)
     {
-      return $this->count($request, Item::class, 'condition_id')
+      return $this->count($request, Item::mine(), 'condition_id')
         ->label(function($value) {
-          return Condition::where('id', $value)->first()->title;
+          return optional(Condition::where('id', $value)->first())->title ?? 'n/a';
         });
     }
 

--- a/app/Nova/Metrics/CollectionPlatformBreakdown.php
+++ b/app/Nova/Metrics/CollectionPlatformBreakdown.php
@@ -18,9 +18,9 @@ class CollectionPlatformBreakdown extends Partition
      */
     public function calculate(NovaRequest $request)
     {
-      return $this->count($request, Item::class, 'platform_id')
+      return $this->count($request, Item::mine(), 'platform_id')
         ->label(function($value) {
-          return Platform::where('id', $value)->first()->title;
+          return optional(Platform::where('id', $value)->first())->title ?? 'n/a';
         });
     }
 

--- a/app/Nova/Metrics/CollectionSizeBreakdown.php
+++ b/app/Nova/Metrics/CollectionSizeBreakdown.php
@@ -18,9 +18,11 @@ class CollectionSizeBreakdown extends Value
     public function calculate(NovaRequest $request)
     {
         if($request->user()->is_admin) {
-          return $this->result(Item::where('created_by', $request->user()->id)->count())
-            ->suffix('Items')
-            ->previous(Item::count());
+          return $this->result(Item::count())
+            ->suffix('Items');
+        } else {
+          return $this->result(Item::mine()->count())
+            ->suffix('Items');
         }
 
     }

--- a/app/Nova/Metrics/CollectionTypeBreakdown.php
+++ b/app/Nova/Metrics/CollectionTypeBreakdown.php
@@ -18,9 +18,9 @@ class CollectionTypeBreakdown extends Partition
      */
     public function calculate(NovaRequest $request)
     {
-        return $this->count($request, Item::class, 'type_id')
+        return $this->count($request, Item::mine(), 'type_id')
           ->label(function($value) {
-            return Type::where('id', $value)->first()->title;
+            return optional(Type::where('id', $value)->first())->title ?? 'n/a';
           });
     }
 


### PR DESCRIPTION
Viewing the seller lens would show everyone's items, not just your own. We obviously don't want that!